### PR TITLE
Consolidated SilkBot namespace to Silk (Silk.Extensions project)

### DIFF
--- a/Silk.Core/Commands/Bot/RequisiteBotPermissions.cs
+++ b/Silk.Core/Commands/Bot/RequisiteBotPermissions.cs
@@ -5,7 +5,7 @@ using DSharpPlus.CommandsNext;
 using DSharpPlus.CommandsNext.Attributes;
 using DSharpPlus.Entities;
 using Silk.Core.Utilities;
-using SilkBot.Extensions;
+using Silk.Extensions;
 
 namespace Silk.Core.Commands.Bot
 {

--- a/Silk.Core/Commands/Economy/DailyCommand.cs
+++ b/Silk.Core/Commands/Economy/DailyCommand.cs
@@ -10,7 +10,7 @@ using Microsoft.EntityFrameworkCore;
 using Silk.Core.Database;
 using Silk.Core.Database.Models;
 using Silk.Core.Utilities;
-using SilkBot.Extensions.DSharpPlus;
+using Silk.Extensions.DSharpPlus;
 
 namespace Silk.Core.Commands.Economy
 {

--- a/Silk.Core/Commands/General/ClearCommand.cs
+++ b/Silk.Core/Commands/General/ClearCommand.cs
@@ -6,7 +6,7 @@ using DSharpPlus.CommandsNext;
 using DSharpPlus.CommandsNext.Attributes;
 using DSharpPlus.Entities;
 using Silk.Core.Utilities;
-using SilkBot.Extensions;
+using Silk.Extensions;
 
 namespace Silk.Core.Commands.General
 {

--- a/Silk.Core/Commands/General/EnlargeCommand.cs
+++ b/Silk.Core/Commands/General/EnlargeCommand.cs
@@ -3,7 +3,7 @@ using DSharpPlus.CommandsNext;
 using DSharpPlus.CommandsNext.Attributes;
 using DSharpPlus.Entities;
 using Silk.Core.Utilities;
-using SilkBot.Extensions;
+using Silk.Extensions;
 
 namespace Silk.Core.Commands.General
 {

--- a/Silk.Core/Commands/General/Tickets/TicketEmbedHelper.cs
+++ b/Silk.Core/Commands/General/Tickets/TicketEmbedHelper.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using DSharpPlus.Entities;
 using Silk.Core.Database.Models;
-using SilkBot.Extensions.DSharpPlus;
+using Silk.Extensions.DSharpPlus;
 
 namespace Silk.Core.Commands.General.Tickets
 {

--- a/Silk.Core/Commands/Miscellaneous/ChangelogCommand.cs
+++ b/Silk.Core/Commands/Miscellaneous/ChangelogCommand.cs
@@ -12,7 +12,7 @@ using Microsoft.EntityFrameworkCore;
 using Silk.Core.Database;
 using Silk.Core.Database.Models;
 using Silk.Core.Services;
-using SilkBot.Extensions;
+using Silk.Extensions;
 
 namespace Silk.Core.Commands.Miscellaneous
 {

--- a/Silk.Core/Commands/Miscellaneous/UserInfoCommand.cs
+++ b/Silk.Core/Commands/Miscellaneous/UserInfoCommand.cs
@@ -10,7 +10,7 @@ using DSharpPlus.CommandsNext;
 using DSharpPlus.CommandsNext.Attributes;
 using DSharpPlus.Entities;
 using Silk.Core.Utilities;
-using SilkBot.Extensions;
+using Silk.Extensions;
 
 namespace Silk.Core.Commands.Miscellaneous
 {

--- a/Silk.Core/Commands/Moderation/Ban/BanCommand.cs
+++ b/Silk.Core/Commands/Moderation/Ban/BanCommand.cs
@@ -9,7 +9,7 @@ using Microsoft.EntityFrameworkCore;
 using Silk.Core.Database;
 using Silk.Core.Database.Models;
 using Silk.Core.Utilities;
-using SilkBot.Extensions;
+using Silk.Extensions;
 
 namespace Silk.Core.Commands.Moderation.Ban
 {

--- a/Silk.Core/Commands/Moderation/Ban/TempBanCommand.cs
+++ b/Silk.Core/Commands/Moderation/Ban/TempBanCommand.cs
@@ -12,8 +12,8 @@ using Silk.Core.Database;
 using Silk.Core.Database.Models;
 using Silk.Core.Tools;
 using Silk.Core.Utilities;
-using SilkBot.Extensions;
-using SilkBot.Extensions.DSharpPlus;
+using Silk.Extensions;
+using Silk.Extensions.DSharpPlus;
 
 namespace Silk.Core.Commands.Moderation.Ban
 {

--- a/Silk.Core/Commands/Moderation/KickCommand.cs
+++ b/Silk.Core/Commands/Moderation/KickCommand.cs
@@ -11,8 +11,8 @@ using Silk.Core.Database.Models;
 using Silk.Core.Services;
 using Silk.Core.Services.Interfaces;
 using Silk.Core.Utilities;
-using SilkBot.Extensions;
-using SilkBot.Extensions.DSharpPlus;
+using Silk.Extensions;
+using Silk.Extensions.DSharpPlus;
 
 namespace Silk.Core.Commands.Moderation
 {

--- a/Silk.Core/Commands/Moderation/TempMuteCommand.cs
+++ b/Silk.Core/Commands/Moderation/TempMuteCommand.cs
@@ -10,7 +10,7 @@ using Silk.Core.Database;
 using Silk.Core.Database.Models;
 using Silk.Core.Tools;
 using Silk.Core.Utilities;
-using SilkBot.Extensions;
+using Silk.Extensions;
 
 namespace Silk.Core.Commands.Moderation
 {

--- a/Silk.Core/Commands/Moderation/UnbanCommand.cs
+++ b/Silk.Core/Commands/Moderation/UnbanCommand.cs
@@ -7,7 +7,7 @@ using DSharpPlus.Entities;
 using Silk.Core.Database.Models;
 using Silk.Core.Tools;
 using Silk.Core.Utilities;
-using SilkBot.Extensions;
+using Silk.Extensions;
 
 namespace Silk.Core.Commands.Moderation
 {

--- a/Silk.Core/Commands/Roles/SetAssignableRole.cs
+++ b/Silk.Core/Commands/Roles/SetAssignableRole.cs
@@ -8,7 +8,7 @@ using Microsoft.EntityFrameworkCore;
 using Silk.Core.Database;
 using Silk.Core.Database.Models;
 using Silk.Core.Utilities;
-using SilkBot.Extensions;
+using Silk.Extensions;
 
 namespace Silk.Core.Commands.Roles
 {

--- a/Silk.Core/Services/InfractionService.cs
+++ b/Silk.Core/Services/InfractionService.cs
@@ -7,7 +7,7 @@ using DSharpPlus.Entities;
 using Microsoft.Extensions.Logging;
 using Silk.Core.Database.Models;
 using Silk.Core.Services.Interfaces;
-using SilkBot.Extensions;
+using Silk.Extensions;
 
 namespace Silk.Core.Services
 {

--- a/Silk.Core/Silk.Core.csproj
+++ b/Silk.Core/Silk.Core.csproj
@@ -15,7 +15,7 @@
     <TieredCompilation>false</TieredCompilation>
     <Authors>VelvetThePanda, CalebABG</Authors>
     <Company>The Silk Devs Team</Company>
-    <PackageProjectUrl>https://github.com/VelvetThePanda/SilkBot</PackageProjectUrl>
+    <PackageProjectUrl>https://github.com/VelvetThePanda/Silk</PackageProjectUrl>
     <UserSecretsId>VelvetThePanda-SilkBot</UserSecretsId>
   </PropertyGroup>
 

--- a/Silk.Core/Tools/EventHelpers/GuildAddedHandler.cs
+++ b/Silk.Core/Tools/EventHelpers/GuildAddedHandler.cs
@@ -10,7 +10,7 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using Silk.Core.Database;
 using Silk.Core.Database.Models;
-using SilkBot.Extensions;
+using Silk.Extensions;
 
 namespace Silk.Core.Tools.EventHelpers
 {
@@ -87,7 +87,7 @@ namespace Silk.Core.Tools.EventHelpers
             sb.Append("Thank you for choosing Silk! to join your server <3")
               .AppendLine("I am a relatively lightweight bot with many functions - partially in moderation, ")
               .AppendLine("partially in games, with many more features to come!")
-              .Append("If there's an issue, feel free to [Open an issue on GitHub](https://github.com/VelvetThePanda/Silkbot/issues), ")
+              .Append("If there's an issue, feel free to [Open an issue on GitHub](https://github.com/VelvetThePanda/Silk/issues), ")
               .AppendLine("or if you're not familiar with GitHub, feel free")
               .AppendLine($"to message the developers directly via {Bot.DefaultCommandPrefix}`ticket create <your message>`.")
               .Append($"By default, the prefix is `{Bot.DefaultCommandPrefix}`, or <@{c.CurrentUser.Id}>, but this can be changed by !setprefix <your prefix here>.");

--- a/Silk.Core/Tools/EventHelpers/RoleAddedHandler.cs
+++ b/Silk.Core/Tools/EventHelpers/RoleAddedHandler.cs
@@ -6,7 +6,7 @@ using Microsoft.EntityFrameworkCore;
 using Serilog;
 using Silk.Core.Database;
 using Silk.Core.Database.Models;
-using SilkBot.Extensions;
+using Silk.Extensions;
 
 namespace Silk.Core.Tools.EventHelpers
 {

--- a/Silk.Core/Tools/EventHelpers/RoleRemovedHelper.cs
+++ b/Silk.Core/Tools/EventHelpers/RoleRemovedHelper.cs
@@ -9,7 +9,7 @@ using Silk.Core.Database;
 using Silk.Core.Database.Models;
 using Silk.Core.Services;
 using Silk.Core.Services.Interfaces;
-using SilkBot.Extensions;
+using Silk.Extensions;
 
 namespace Silk.Core.Tools.EventHelpers
 {

--- a/Silk.Core/Utilities/BotEventSubscriber.cs
+++ b/Silk.Core/Utilities/BotEventSubscriber.cs
@@ -6,7 +6,7 @@ using DSharpPlus.CommandsNext;
 using Microsoft.Extensions.Logging;
 using Silk.Core.AutoMod;
 using Silk.Core.Tools.EventHelpers;
-using SilkBot.Extensions;
+using Silk.Extensions;
 
 namespace Silk.Core.Utilities
 {

--- a/Silk.Core/Utilities/EmbedHelper.cs
+++ b/Silk.Core/Utilities/EmbedHelper.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using DSharpPlus.CommandsNext;
 using DSharpPlus.Entities;
-using SilkBot.Extensions;
+using Silk.Extensions;
 
 namespace Silk.Core.Utilities
 {

--- a/Silk.Core/Utilities/HelpFormatter.cs
+++ b/Silk.Core/Utilities/HelpFormatter.cs
@@ -8,7 +8,7 @@ using DSharpPlus.CommandsNext.Attributes;
 using DSharpPlus.CommandsNext.Converters;
 using DSharpPlus.CommandsNext.Entities;
 using DSharpPlus.Entities;
-using SilkBot.Extensions;
+using Silk.Extensions;
 
 namespace Silk.Core.Utilities
 {

--- a/Silk.Core/Utilities/RequireFlagAttribute.cs
+++ b/Silk.Core/Utilities/RequireFlagAttribute.cs
@@ -7,7 +7,7 @@ using DSharpPlus.CommandsNext.Attributes;
 using Microsoft.EntityFrameworkCore;
 using Silk.Core.Database;
 using Silk.Core.Database.Models;
-using SilkBot.Extensions;
+using Silk.Extensions;
 
 namespace Silk.Core.Utilities
 {

--- a/Silk.Extensions/ArrayExtension.cs
+++ b/Silk.Extensions/ArrayExtension.cs
@@ -4,7 +4,7 @@ using System.Linq;
 
 #endregion
 
-namespace SilkBot.Extensions
+namespace Silk.Extensions
 {
     public static class ArrayExtension
     {

--- a/Silk.Extensions/CollectionExtensions.cs
+++ b/Silk.Extensions/CollectionExtensions.cs
@@ -7,7 +7,7 @@ using System.Linq;
 
 #endregion
 
-namespace SilkBot.Extensions
+namespace Silk.Extensions
 {
     public static class CollectionExtensions
     {

--- a/Silk.Extensions/CommandContextExtensions.cs
+++ b/Silk.Extensions/CommandContextExtensions.cs
@@ -8,7 +8,7 @@ using DSharpPlus.Entities;
 
 #endregion
 
-namespace SilkBot.Extensions
+namespace Silk.Extensions
 {
     public static class CommandContextExtensions
     {

--- a/Silk.Extensions/DSharpPlus/DateTimeExtensions.cs
+++ b/Silk.Extensions/DSharpPlus/DateTimeExtensions.cs
@@ -4,7 +4,7 @@ using System;
 
 #endregion
 
-namespace SilkBot.Extensions.DSharpPlus
+namespace Silk.Extensions.DSharpPlus
 {
     public static class DateTimeExtensions
     {

--- a/Silk.Extensions/DSharpPlus/DiscordClientExtensions.cs
+++ b/Silk.Extensions/DSharpPlus/DiscordClientExtensions.cs
@@ -6,7 +6,7 @@ using DSharpPlus.Entities;
 
 #endregion
 
-namespace SilkBot.Extensions.DSharpPlus
+namespace Silk.Extensions.DSharpPlus
 {
     public static class DiscordClientExtensions
     {

--- a/Silk.Extensions/DSharpPlus/DiscordMessageExtensions.cs
+++ b/Silk.Extensions/DSharpPlus/DiscordMessageExtensions.cs
@@ -8,7 +8,7 @@ using DSharpPlus.Entities;
 
 #endregion
 
-namespace SilkBot.Extensions.DSharpPlus
+namespace Silk.Extensions.DSharpPlus
 {
     public static class DiscordMessageExtensions
     {

--- a/Silk.Extensions/DSharpPlus/DiscordUserExtensions.cs
+++ b/Silk.Extensions/DSharpPlus/DiscordUserExtensions.cs
@@ -4,7 +4,7 @@ using DSharpPlus.Entities;
 
 #endregion
 
-namespace SilkBot.Extensions.DSharpPlus
+namespace Silk.Extensions.DSharpPlus
 {
     public static class DiscordUserExtensions
     {

--- a/Silk.Extensions/EnumExtension.cs
+++ b/Silk.Extensions/EnumExtension.cs
@@ -4,7 +4,7 @@ using System;
 
 #endregion
 
-namespace SilkBot.Extensions
+namespace Silk.Extensions
 {
     public static class EnumerationExtensions
     {

--- a/Silk.Extensions/IServiceCollectionExtensions.cs
+++ b/Silk.Extensions/IServiceCollectionExtensions.cs
@@ -6,7 +6,7 @@ using DSharpPlus;
 
 #endregion
 
-namespace SilkBot.Extensions
+namespace Silk.Extensions
 {
     public static class IServiceCollectionExtensions
     {

--- a/Silk.Extensions/PermissionHelper.cs
+++ b/Silk.Extensions/PermissionHelper.cs
@@ -7,7 +7,7 @@ using DSharpPlus.Entities;
 
 #endregion
 
-namespace SilkBot.Extensions
+namespace Silk.Extensions
 {
     public static class PermissionHelper
     {

--- a/Silk.Extensions/Silk.Extensions.csproj
+++ b/Silk.Extensions/Silk.Extensions.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
-    <RootNamespace>SilkBot.Extensions</RootNamespace>
+    <RootNamespace>Silk.Extensions</RootNamespace>
     <AssemblyName>Silk.Extensions</AssemblyName>
     <LangVersion>9</LangVersion>
   </PropertyGroup>

--- a/Silk.Extensions/StringExtensions.cs
+++ b/Silk.Extensions/StringExtensions.cs
@@ -5,7 +5,7 @@ using System.Linq;
 
 #endregion
 
-namespace SilkBot.Extensions
+namespace Silk.Extensions
 {
     public static class StringExtensions
     {


### PR DESCRIPTION
Silk.Extensions
- Updated Silk.Extensions.csproj RootNamespace Tag to use "Silk.Extensions" namespace
- Updated all files in project to use new root namespace

Silk.Core.csproj
- Updated Silk.Core.csproj PackageProjectUrl Tag to use updated Github url for SIlk project
- Updated all files which used old "SilkBot" namespace to use updated namespace