### PR TITLE
Update the returned Embed for the `perms` command

### DIFF
--- a/src/Silk.Core/Commands/Bot/RequisiteBotPermissions.cs
+++ b/src/Silk.Core/Commands/Bot/RequisiteBotPermissions.cs
@@ -18,13 +18,12 @@ namespace Silk.Core.Commands.Bot
         {
             string prefix = ctx.Prefix;
 
-            var descriptionAttribute = GetType().GetMethod(nameof(GetRequiredPermissions))!
-                .GetCustomAttribute<DescriptionAttribute>();
+            var description = ctx.Command.Description;
 
             DiscordEmbedBuilder embed = new DiscordEmbedBuilder()
                 .WithColor(DiscordColor.CornflowerBlue)
                 .WithTitle("Silk's Permissions:")
-                .WithDescription(descriptionAttribute?.Description + "\n");
+                .WithDescription(description + "\n");
 
             DiscordMember bot = await ctx.Guild.GetMemberAsync(ctx.Client.CurrentUser.Id);
 

--- a/src/Silk.Core/Commands/Bot/RequisiteBotPermissions.cs
+++ b/src/Silk.Core/Commands/Bot/RequisiteBotPermissions.cs
@@ -1,4 +1,4 @@
-﻿using System.Text;
+﻿using System.Reflection;
 using System.Threading.Tasks;
 using DSharpPlus;
 using DSharpPlus.CommandsNext;
@@ -18,7 +18,14 @@ namespace Silk.Core.Commands.Bot
         {
             string prefix = ctx.Prefix;
 
-            DiscordEmbedBuilder embed = EmbedHelper.CreateEmbed(ctx, "Permissions:", DiscordColor.CornflowerBlue);
+            var descriptionAttribute = GetType().GetMethod(nameof(GetRequiredPermissions))!
+                .GetCustomAttribute<DescriptionAttribute>();
+
+            DiscordEmbedBuilder embed = new DiscordEmbedBuilder()
+                .WithColor(DiscordColor.CornflowerBlue)
+                .WithTitle("Silk's Permissions:")
+                .WithDescription(descriptionAttribute?.Description + "\n");
+
             DiscordMember bot = await ctx.Guild.GetMemberAsync(ctx.Client.CurrentUser.Id);
 
             bool manageMessage = bot.HasPermission(Permissions.ManageMessages);
@@ -26,17 +33,13 @@ namespace Silk.Core.Commands.Bot
             bool ban = bot.HasPermission(Permissions.BanMembers);
             bool manageRoles = bot.HasPermission(Permissions.ManageRoles);
 
-            var sb = new StringBuilder();
+            // Todo: Match / Collect commands with permissions the bot needs (could be based on Attribute), so the command names below can be updated dynamically
 
-            sb.AppendLine($"`Manage Messages`: {GetStatusEmoji(manageMessage)}\nAffected commands: `{prefix}clear`, " +
-                          $"`{prefix}clean`; __error messages will persist if false.__\n");
-            sb.AppendLine($"`Manage Roles`: {GetStatusEmoji(manageRoles)}\nAffected commands: `{prefix}role`\n");
-            sb.AppendLine($"`Kick Members` {GetStatusEmoji(kick)}\nAffected commands: `{prefix}kick`\n");
-            sb.AppendLine($"`Ban Members` {GetStatusEmoji(ban)}\nAffected commands: `{prefix}ban`\n");
-
-            embed.WithTitle("Permissions:");
-            embed.WithDescription(sb.ToString());
-
+            embed.AddField($"`Manage Messages` {GetStatusEmoji(manageMessage)}\n", $"Affected commands: `{prefix} clear`, " + $"`{prefix} clean`; __error messages will persist if false.__\n");
+            embed.AddField($"`Manage Roles` {GetStatusEmoji(manageRoles)}\n", $"Affected commands: `{prefix} role-info`\n");
+            embed.AddField($"`Kick Members` {GetStatusEmoji(kick)}\n", $"Affected commands: `{prefix} kick`\n");
+            embed.AddField($"`Ban Members` {GetStatusEmoji(ban)}\n", $"Affected commands: `{prefix} ban`\n");
+            
             await ctx.RespondAsync(embed: embed);
         }
 


### PR DESCRIPTION
Issue:
- If NOT using the `<prefix> help perms` command to get the description of the `perms` command, it could be confusing as to whether the permissions listed are for the bot itself or the user issuing the command

Resolution:
- The title of the command lists the bot's name (Silk) to let anyone requesting know the command is specifically about the bot
- There is a description below the title which is pulled from the DescriptionAttribute Attribute decorated on the method, which gives the full details as to what the command does and who it's aimed at