### PR TITLE
Consolidate Silk Configuration Options

### DIFF
--- a/src/Silk.Core/Startup.cs
+++ b/src/Silk.Core/Startup.cs
@@ -24,6 +24,7 @@ using Silk.Core.Services;
 using Silk.Core.Services.Interfaces;
 using Silk.Core.Utilities;
 using Silk.Core.Utilities.Bot;
+using Silk.Shared.Configuration;
 using Silk.Shared.Constants;
 
 namespace Silk.Core
@@ -95,7 +96,10 @@ namespace Silk.Core
             return builder.ConfigureServices((context, services) =>
             {
                 IConfiguration? config = context.Configuration;
+                
+                AddSilkConfigurationOptions(services, config);
                 AddDatabases(services, config.GetConnectionString("core"));
+                
                 if (!addServices) return;
                 services.AddScoped(typeof(ILogger<>), typeof(Shared.Types.Logger<>));
 
@@ -175,6 +179,14 @@ namespace Silk.Core
                 c.Database.Migrate();
         }
 
+        private static void AddSilkConfigurationOptions(IServiceCollection services, IConfiguration configuration)
+        {
+            // Add and Bind IOptions configuration for appSettings.json and UserSecrets configuration structure
+            // https://docs.microsoft.com/en-us/aspnet/core/fundamentals/configuration/options?view=aspnetcore-5.0
+            var silkConfigurationSection = configuration.GetSection(SilkConfigurationOptions.SectionKey);
+            services.Configure<SilkConfigurationOptions>(silkConfigurationSection);
+        }
+        
         private static void AddDatabases(IServiceCollection services, string connectionString)
         {
             void Builder(DbContextOptionsBuilder b)

--- a/src/Silk.Shared/Configuration/SilkConfigurationOptions.cs
+++ b/src/Silk.Shared/Configuration/SilkConfigurationOptions.cs
@@ -1,0 +1,96 @@
+﻿namespace Silk.Shared.Configuration
+{
+    /// <summary>
+    /// A class which holds configuration information bound from an AppSettings or UserSecrets file.
+    /// To be used with IOptions and configured in ConfigureServices in a Startup.cs file />
+    ///
+    /// Properties within this class correlate to the name of the key or sub-key property in the configuration file:
+    /// Ex. Below, the "Persistence" key correlated to the Persistence property in this class with the same name
+    /// <code>
+    /// {
+    ///     /* Root */
+    ///     "Silk":
+    ///     {
+    ///         /* Sub-Key property name */
+    ///         "Persistence": {...}
+    ///     }
+    /// }
+    /// </code>
+    /// </summary>
+    public class SilkConfigurationOptions
+    {
+        /// <summary>
+        /// The name of the root configuration options property in the file
+        /// </summary>
+        public const string SectionKey = "Silk";
+
+        /// <summary>
+        /// Property for whether this bot is self-hosted or not
+        /// </summary>
+        public bool SelfHosted { get; set; }
+
+        /// <summary>
+        /// Property for holding Persistence options (property name matching sub-key property in configuration file)
+        /// </summary>
+        public SilkPersistenceOptions Persistence { get; set; }
+
+        /// <summary>
+        /// Property for holding Discord Developer Api options (property name matching sub-key property in configuration file)
+        /// </summary>
+        public SilkDiscordOptions Discord { get; set; }
+
+        /// <summary>
+        /// Property for holding Discord Developer Api options (property name matching sub-key property in configuration file)
+        /// </summary>
+        public SilkE621Options E621 { get; set; }
+
+        /// <summary>
+        /// Convenience method to compose the ConnectionString based on the provided Persistence options
+        /// <see cref="SilkPersistenceOptions"/>
+        /// </summary>
+        /// <returns>The full connection string given the options, or invalid/incomplete connection string if pieces of configuration file are left blank</returns>
+        public string GetConnectionString()
+        {
+            return $"Server={Persistence.Host};" +
+                   $"Port={Persistence.Port};" +
+                   $"Database={Persistence.Database};" +
+                   $"Username={Persistence.Username};" +
+                   $"Password={Persistence.Password};";
+        }
+    }
+
+    /// <summary>
+    /// Class which holds configuration information for the Database Connection properties
+    /// <para>Note: Silk by default uses PostgresSQL, so the class is templated based off connection string convention for PostgreSQL</para>
+    ///
+    /// <para>A pre-configured <b>docker-compose.yml</b> file can be found <a href="https://files.velvetthepanda.dev/docker/postgres/docker-compose.yml">here</a></para>
+    /// <para>Default Username and Password: "silk".</para>
+    /// </summary>
+    public class SilkPersistenceOptions
+    {
+        public string Host { get; set; } = "localhost";
+        public string Port { get; set; } = "5432";
+        public string Database { get; set; } = string.Empty;
+        public string Username { get; set; } = "postgres";
+        public string Password { get; set; } = string.Empty;
+    }
+
+    /// <summary>
+    /// Class which holds configuration information for the Discord Developer Api properties
+    /// </summary>
+    public class SilkDiscordOptions
+    {
+        public string ClientId { get; set; } = string.Empty;
+        public string ClientSecret { get; set; } = string.Empty;
+        public string BotToken { get; set; } = string.Empty;
+    }
+
+    /// <summary>
+    /// Class which holds configuration information for the E621 Api properties
+    /// </summary>
+    public class SilkE621Options
+    {
+        public string ApiKey { get; set; } = string.Empty;
+        public string Username { get; set; } = string.Empty;
+    }
+}

--- a/src/Silk.Shared/Configuration/SilkConfigurationOptions.cs
+++ b/src/Silk.Shared/Configuration/SilkConfigurationOptions.cs
@@ -5,7 +5,7 @@
     /// To be used with IOptions and configured in ConfigureServices in a Startup.cs file />
     ///
     /// Properties within this class correlate to the name of the key or sub-key property in the configuration file:
-    /// Ex. Below, the "Persistence" key correlated to the Persistence property in this class with the same name
+    /// Ex. Below, the "Persistence" key correlates to the Persistence property in this class with the same name
     /// <code>
     /// {
     ///     /* Root */
@@ -63,7 +63,8 @@
     /// <summary>
     /// Class which holds configuration information for the Database Connection properties
     /// <para>Note: Silk by default uses PostgresSQL, so the class is templated based off connection string convention for PostgreSQL</para>
-    /// <para>A pre-configured <b>docker-compose.yml</b> file can be found <a href="https://files.velvetthepanda.dev/docker/postgres/docker-compose.yml">here</a></para>
+    /// <para>A pre-configured <b>docker-compose.yml</b> file can be found
+    /// <a href="https://files.velvetthepanda.dev/docker/postgres/docker-compose.yml">here</a></para>
     /// <para>Default Username and Password: "silk".</para>
     /// </summary>
     public class SilkPersistenceOptions

--- a/src/Silk.Shared/Configuration/SilkConfigurationOptions.cs
+++ b/src/Silk.Shared/Configuration/SilkConfigurationOptions.cs
@@ -25,7 +25,8 @@
         public const string SectionKey = "Silk";
 
         /// <summary>
-        /// Property for whether this bot is self-hosted or not
+        /// Property for whether this bot is self-hosted or not. 
+        /// <remarks>Setting to false may lead to broken features that rely on specific information/services that are unavailable in self-hosted instances.</remarks>
         /// </summary>
         public bool SelfHosted { get; set; }
 
@@ -62,7 +63,6 @@
     /// <summary>
     /// Class which holds configuration information for the Database Connection properties
     /// <para>Note: Silk by default uses PostgresSQL, so the class is templated based off connection string convention for PostgreSQL</para>
-    ///
     /// <para>A pre-configured <b>docker-compose.yml</b> file can be found <a href="https://files.velvetthepanda.dev/docker/postgres/docker-compose.yml">here</a></para>
     /// <para>Default Username and Password: "silk".</para>
     /// </summary>
@@ -80,6 +80,7 @@
     /// </summary>
     public class SilkDiscordOptions
     {
+        public int Shards {get; set; } = 1;
         public string ClientId { get; set; } = string.Empty;
         public string ClientSecret { get; set; } = string.Empty;
         public string BotToken { get; set; } = string.Empty;

--- a/src/Silk.Shared/Configuration/SilkConfigurationOptions.cs
+++ b/src/Silk.Shared/Configuration/SilkConfigurationOptions.cs
@@ -2,8 +2,12 @@
 {
     /// <summary>
     /// A class which holds configuration information bound from an AppSettings or UserSecrets file.
-    /// To be used with IOptions and configured in ConfigureServices in a Startup.cs file />
+    /// To be used with IOptions and configured in ConfigureServices in a Startup.cs file.<br/>
     ///
+    /// <para>More info about <b>Options Pattern</b> can be found on Microsoft Docs
+    /// <a href="https://docs.microsoft.com/en-us/aspnet/core/fundamentals/configuration/options?view=aspnetcore-5.0">Options pattern in ASP.NET Core</a>
+    /// </para><br/>
+    /// 
     /// Properties within this class correlate to the name of the key or sub-key property in the configuration file:
     /// Ex. Below, the "Persistence" key correlates to the Persistence property in this class with the same name
     /// <code>

--- a/src/Silk.Shared/Configuration/SilkConfigurationOptions.cs
+++ b/src/Silk.Shared/Configuration/SilkConfigurationOptions.cs
@@ -26,7 +26,7 @@
 
         /// <summary>
         /// Property for whether this bot is self-hosted or not. 
-        /// <remarks>Setting to false may lead to broken features that rely on specific information/services that are unavailable in self-hosted instances.</remarks>
+        /// <remarks>Setting to true may lead to broken features that rely on specific information/services that are unavailable in self-hosted instances.</remarks>
         /// </summary>
         public bool SelfHosted { get; set; }
 

--- a/src/Silk.Shared/Configuration/appsettings.example.json
+++ b/src/Silk.Shared/Configuration/appsettings.example.json
@@ -1,0 +1,21 @@
+﻿{
+  "Silk": {
+    "SelfHosted": false,
+    "Persistence": {
+      "Host": "localhost",
+      "Port": "5432",
+      "Database": "<database-name>",
+      "Username": "postgres",
+      "Password": "<database-user-password>"
+    },
+    "Discord": {
+      "ClientId": "<discord-client-id>",
+      "ClientSecret": "<discord-client-secret>",
+      "BotToken": "<discord-bot-token>"
+    },
+    "E621": {
+      "ApiKey": "<api-key>",
+      "Username": "<username>"
+    }
+  }
+}

--- a/src/Silk.Shared/Configuration/appsettings.example.json
+++ b/src/Silk.Shared/Configuration/appsettings.example.json
@@ -9,6 +9,7 @@
       "Password": "<database-user-password>"
     },
     "Discord": {
+      "Shards": 1,
       "ClientId": "<discord-client-id>",
       "ClientSecret": "<discord-client-secret>",
       "BotToken": "<discord-bot-token>"


### PR DESCRIPTION
This pull request adds the ability to use a concrete class 'SilkConfigurationOptions' to grab configuration properties and data, over manually needing to access the IConfiguration property by key to get a configuration value (in most cases).