### PR TITLE
Add option to configuration for setting the guild to use with slash command registration

### DIFF
--- a/src/Silk.Core/appSettings.json
+++ b/src/Silk.Core/appSettings.json
@@ -1,6 +1,7 @@
 {
   "Silk": {
     "SelfHosted": false,
+    "SlashCommandsGuildId": null,
     "LogLevel": "Info",
     "Persistence": {
       "Host": "localhost",

--- a/src/Silk.Shared/Configuration/SilkConfigurationOptions.cs
+++ b/src/Silk.Shared/Configuration/SilkConfigurationOptions.cs
@@ -45,6 +45,12 @@ namespace Silk.Shared.Configuration
         public string LogLevel { get; set; } = "Info";
 
         /// <summary>
+        /// Property for determining whether to use global or guild specific slash commands.
+        /// Leave null for global slash commands.
+        /// </summary>
+        public ulong? SlashCommandsGuildId { get; set; } = null;
+
+        /// <summary>
         /// Property for holding Persistence options (property name matching sub-key property in configuration file)
         /// </summary>
         public SilkPersistenceOptions Persistence { get; set; }


### PR DESCRIPTION
Add property to appSettings.json and SilkConfigurationOptions.cs to enable users to set which guild they'd like to register slash commands