### PR TITLE
Add improved slash command service*

### DIFF
--- a/Silk.sln
+++ b/Silk.sln
@@ -41,6 +41,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PluginLoader.Unity", "plugi
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AnnoucementPlugin", "plugins\AnnoucementPlugin\AnnoucementPlugin.csproj", "{F1669FB0-5345-4EB4-A7D1-9AFCF674BD1A}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Silk.Remora.SlashCommands", "src\Silk.Remora.SlashCommands\Silk.Remora.SlashCommands.csproj", "{300F88DF-46A6-4F37-9E88-B51BECFBD65A}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -145,6 +147,14 @@ Global
 		{F1669FB0-5345-4EB4-A7D1-9AFCF674BD1A}.Release|Any CPU.Build.0 = Release|Any CPU
 		{F1669FB0-5345-4EB4-A7D1-9AFCF674BD1A}.Release|x64.ActiveCfg = Release|Any CPU
 		{F1669FB0-5345-4EB4-A7D1-9AFCF674BD1A}.Release|x64.Build.0 = Release|Any CPU
+		{300F88DF-46A6-4F37-9E88-B51BECFBD65A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{300F88DF-46A6-4F37-9E88-B51BECFBD65A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{300F88DF-46A6-4F37-9E88-B51BECFBD65A}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{300F88DF-46A6-4F37-9E88-B51BECFBD65A}.Debug|x64.Build.0 = Debug|Any CPU
+		{300F88DF-46A6-4F37-9E88-B51BECFBD65A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{300F88DF-46A6-4F37-9E88-B51BECFBD65A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{300F88DF-46A6-4F37-9E88-B51BECFBD65A}.Release|x64.ActiveCfg = Release|Any CPU
+		{300F88DF-46A6-4F37-9E88-B51BECFBD65A}.Release|x64.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -165,5 +175,6 @@ Global
 		{4433A4CF-96C8-4C44-9566-7E343BCD11E2} = {A0792A2C-F57F-4E0F-A196-E0B0EE2FE60F}
 		{478B4FE9-42F9-406E-913D-6EA27AD7C5BF} = {A0792A2C-F57F-4E0F-A196-E0B0EE2FE60F}
 		{F1669FB0-5345-4EB4-A7D1-9AFCF674BD1A} = {A0792A2C-F57F-4E0F-A196-E0B0EE2FE60F}
+		{300F88DF-46A6-4F37-9E88-B51BECFBD65A} = {FE9BF140-0795-4CBE-A5A1-E37A36081587}
 	EndGlobalSection
 EndGlobal

--- a/src/Silk.Remora.SlashCommands/LICENSE
+++ b/src/Silk.Remora.SlashCommands/LICENSE
@@ -1,0 +1,165 @@
+                   GNU LESSER GENERAL PUBLIC LICENSE
+                       Version 3, 29 June 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+
+  This version of the GNU Lesser General Public License incorporates
+the terms and conditions of version 3 of the GNU General Public
+License, supplemented by the additional permissions listed below.
+
+  0. Additional Definitions.
+
+  As used herein, "this License" refers to version 3 of the GNU Lesser
+General Public License, and the "GNU GPL" refers to version 3 of the GNU
+General Public License.
+
+  "The Library" refers to a covered work governed by this License,
+other than an Application or a Combined Work as defined below.
+
+  An "Application" is any work that makes use of an interface provided
+by the Library, but which is not otherwise based on the Library.
+Defining a subclass of a class defined by the Library is deemed a mode
+of using an interface provided by the Library.
+
+  A "Combined Work" is a work produced by combining or linking an
+Application with the Library.  The particular version of the Library
+with which the Combined Work was made is also called the "Linked
+Version".
+
+  The "Minimal Corresponding Source" for a Combined Work means the
+Corresponding Source for the Combined Work, excluding any source code
+for portions of the Combined Work that, considered in isolation, are
+based on the Application, and not on the Linked Version.
+
+  The "Corresponding Application Code" for a Combined Work means the
+object code and/or source code for the Application, including any data
+and utility programs needed for reproducing the Combined Work from the
+Application, but excluding the System Libraries of the Combined Work.
+
+  1. Exception to Section 3 of the GNU GPL.
+
+  You may convey a covered work under sections 3 and 4 of this License
+without being bound by section 3 of the GNU GPL.
+
+  2. Conveying Modified Versions.
+
+  If you modify a copy of the Library, and, in your modifications, a
+facility refers to a function or data to be supplied by an Application
+that uses the facility (other than as an argument passed when the
+facility is invoked), then you may convey a copy of the modified
+version:
+
+   a) under this License, provided that you make a good faith effort to
+   ensure that, in the event an Application does not supply the
+   function or data, the facility still operates, and performs
+   whatever part of its purpose remains meaningful, or
+
+   b) under the GNU GPL, with none of the additional permissions of
+   this License applicable to that copy.
+
+  3. Object Code Incorporating Material from Library Header Files.
+
+  The object code form of an Application may incorporate material from
+a header file that is part of the Library.  You may convey such object
+code under terms of your choice, provided that, if the incorporated
+material is not limited to numerical parameters, data structure
+layouts and accessors, or small macros, inline functions and templates
+(ten or fewer lines in length), you do both of the following:
+
+   a) Give prominent notice with each copy of the object code that the
+   Library is used in it and that the Library and its use are
+   covered by this License.
+
+   b) Accompany the object code with a copy of the GNU GPL and this license
+   document.
+
+  4. Combined Works.
+
+  You may convey a Combined Work under terms of your choice that,
+taken together, effectively do not restrict modification of the
+portions of the Library contained in the Combined Work and reverse
+engineering for debugging such modifications, if you also do each of
+the following:
+
+   a) Give prominent notice with each copy of the Combined Work that
+   the Library is used in it and that the Library and its use are
+   covered by this License.
+
+   b) Accompany the Combined Work with a copy of the GNU GPL and this license
+   document.
+
+   c) For a Combined Work that displays copyright notices during
+   execution, include the copyright notice for the Library among
+   these notices, as well as a reference directing the user to the
+   copies of the GNU GPL and this license document.
+
+   d) Do one of the following:
+
+       0) Convey the Minimal Corresponding Source under the terms of this
+       License, and the Corresponding Application Code in a form
+       suitable for, and under terms that permit, the user to
+       recombine or relink the Application with a modified version of
+       the Linked Version to produce a modified Combined Work, in the
+       manner specified by section 6 of the GNU GPL for conveying
+       Corresponding Source.
+
+       1) Use a suitable shared library mechanism for linking with the
+       Library.  A suitable mechanism is one that (a) uses at run time
+       a copy of the Library already present on the user's computer
+       system, and (b) will operate properly with a modified version
+       of the Library that is interface-compatible with the Linked
+       Version.
+
+   e) Provide Installation Information, but only if you would otherwise
+   be required to provide such information under section 6 of the
+   GNU GPL, and only to the extent that such information is
+   necessary to install and execute a modified version of the
+   Combined Work produced by recombining or relinking the
+   Application with a modified version of the Linked Version. (If
+   you use option 4d0, the Installation Information must accompany
+   the Minimal Corresponding Source and Corresponding Application
+   Code. If you use option 4d1, you must provide the Installation
+   Information in the manner specified by section 6 of the GNU GPL
+   for conveying Corresponding Source.)
+
+  5. Combined Libraries.
+
+  You may place library facilities that are a work based on the
+Library side by side in a single library together with other library
+facilities that are not Applications and are not covered by this
+License, and convey such a combined library under terms of your
+choice, if you do both of the following:
+
+   a) Accompany the combined library with a copy of the same work based
+   on the Library, uncombined with any other library facilities,
+   conveyed under the terms of this License.
+
+   b) Give prominent notice with the combined library that part of it
+   is a work based on the Library, and explaining where to find the
+   accompanying uncombined form of the same work.
+
+  6. Revised Versions of the GNU Lesser General Public License.
+
+  The Free Software Foundation may publish revised and/or new versions
+of the GNU Lesser General Public License from time to time. Such new
+versions will be similar in spirit to the present version, but may
+differ in detail to address new problems or concerns.
+
+  Each version is given a distinguishing version number. If the
+Library as you received it specifies that a certain numbered version
+of the GNU Lesser General Public License "or any later version"
+applies to it, you have the option of following the terms and
+conditions either of that published version or of any later version
+published by the Free Software Foundation. If the Library as you
+received it does not specify a version number of the GNU Lesser
+General Public License, you may choose any version of the GNU Lesser
+General Public License ever published by the Free Software Foundation.
+
+  If the Library as you received it specifies that a proxy can decide
+whether future versions of the GNU Lesser General Public License shall
+apply, that proxy's public statement of acceptance of any version is
+permanent authorization for you to choose that version for the
+Library.	

--- a/src/Silk.Remora.SlashCommands/Silk.Remora.SlashCommands.csproj
+++ b/src/Silk.Remora.SlashCommands/Silk.Remora.SlashCommands.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="JetBrains.Annotations" Version="2021.3.0" />
+    <PackageReference Include="Remora.Commands" Version="7.1.5" />
+    <PackageReference Include="Remora.Discord.API.Abstractions" Version="47.0.2" />
+    <PackageReference Include="Remora.Discord.Commands" Version="14.0.3" />
+    <PackageReference Include="System.CommandLine" Version="2.0.0-beta1.20574.7" />
+  </ItemGroup>
+
+</Project>

--- a/src/Silk.Remora.SlashCommands/SlashCommandIdentifier.cs
+++ b/src/Silk.Remora.SlashCommands/SlashCommandIdentifier.cs
@@ -1,0 +1,10 @@
+using Remora.Rest.Core;
+
+namespace Silk.Remora.SlashCommands;
+
+/// <summary>
+/// Represents an identifier for an application command, where the Guild ID may not be present.
+/// </summary>
+/// <param name="GuildID">The ID of the guild the command is registered for, if any.</param>
+/// <param name="CommandID">The ID of the command that was registered.</param>
+public record SlashCommandIdentifier(Optional<Snowflake> GuildID, Snowflake CommandID);

--- a/src/Silk.Remora.SlashCommands/SlashCommandService.cs
+++ b/src/Silk.Remora.SlashCommands/SlashCommandService.cs
@@ -1,0 +1,21 @@
+using JetBrains.Annotations;
+using Remora.Commands.Trees;
+using Remora.Discord.API.Abstractions.Rest;
+
+namespace Silk.Remora.SlashCommands;
+
+[PublicAPI]
+public class SlashCommandService
+{
+    private readonly CommandTree                _commandTree;
+    private readonly IDiscordRestOAuth2API      _oauth2API;
+    private readonly IDiscordRestApplicationAPI _applicationAPI;
+    
+    public SlashCommandService(CommandTree commandTree, IDiscordRestOAuth2API oauth2API, IDiscordRestApplicationAPI applicationAPI)
+    {
+        _commandTree = commandTree;
+        _oauth2API = oauth2API;
+        _applicationAPI = applicationAPI;
+    }
+    
+}

--- a/src/Silk.Remora.SlashCommands/SlashCommandService.cs
+++ b/src/Silk.Remora.SlashCommands/SlashCommandService.cs
@@ -1,6 +1,11 @@
 using JetBrains.Annotations;
+using OneOf;
 using Remora.Commands.Trees;
+using Remora.Commands.Trees.Nodes;
 using Remora.Discord.API.Abstractions.Rest;
+using Remora.Discord.Commands.Extensions;
+using Remora.Rest.Core;
+using Remora.Results;
 
 namespace Silk.Remora.SlashCommands;
 
@@ -11,11 +16,56 @@ public class SlashCommandService
     private readonly IDiscordRestOAuth2API      _oauth2API;
     private readonly IDiscordRestApplicationAPI _applicationAPI;
     
+    public IReadOnlyDictionary<SlashCommandIdentifier, OneOf<CommandNode, IReadOnlyDictionary<string, CommandNode>>> RegisteredCommands { get; private set; }
+
     public SlashCommandService(CommandTree commandTree, IDiscordRestOAuth2API oauth2API, IDiscordRestApplicationAPI applicationAPI)
     {
         _commandTree = commandTree;
         _oauth2API = oauth2API;
         _applicationAPI = applicationAPI;
+
+        RegisteredCommands = new Dictionary<SlashCommandIdentifier, OneOf<CommandNode, IReadOnlyDictionary<string, CommandNode>>>();
     }
+
+    public async Task<Result> UpdateSlashCommandsAsync
+    (
+        Snowflake?        guildID = null,
+        CancellationToken ct      = default
+    )
+    {
+        var appResult = await _oauth2API.GetCurrentBotApplicationInformationAsync(ct);
+
+        if (!appResult.IsDefined(out var app))
+            return Result.FromError(appResult);
+        
+        var createCommands = _commandTree.CreateApplicationCommands();
+        
+        if (!createCommands.IsDefined(out var commands))
+            return Result.FromError(createCommands);
+        
+        var updateResult = await
+            (
+                guildID is null
+                    ? _applicationAPI.BulkOverwriteGlobalApplicationCommandsAsync(app.ID, commands, ct)
+                    : _applicationAPI.BulkOverwriteGuildApplicationCommandsAsync(app.ID, guildID.Value, commands, ct)
+            );
+
+        if (!updateResult.IsDefined(out var updatedCommands))
+            return Result.FromError(updateResult);
+        
+        var mergedCommands = new Dictionary<SlashCommandIdentifier, OneOf<CommandNode, IReadOnlyDictionary<string, CommandNode>>>(RegisteredCommands);
+
+        var updatedMappings = _commandTree.MapApplicationCommands(updatedCommands);
+        
+        foreach (var (key, value) in updatedMappings)
+        {
+            mergedCommands[key] = value;
+        }
+        
+        RegisteredCommands = mergedCommands;
+        
+        return Result.FromSuccess();
+    }
+    
     
 }

--- a/src/Silk.Remora.SlashCommands/TreeExtensions.cs
+++ b/src/Silk.Remora.SlashCommands/TreeExtensions.cs
@@ -1,0 +1,113 @@
+using System.Text.RegularExpressions;
+using OneOf;
+using Remora.Commands.Trees;
+using Remora.Commands.Trees.Nodes;
+using Remora.Discord.API.Abstractions.Objects;
+using Remora.Discord.Commands.Extensions;
+using static Remora.Discord.API.Abstractions.Objects.ApplicationCommandOptionType;
+
+namespace Silk.Remora.SlashCommands;
+
+/// <summary>
+/// <para>
+/// An implementation of extensions for <see cref="CommandTree"/> that behaves
+/// similar to <see cref="CommandTreeExtensions"/>, but only registers commands
+/// that are opt IN.
+/// </para>
+/// <remarks>
+/// For the inclined, <see cref="CommandTreeExtensions"/> will attmept to register
+/// all types listed in the command tree regardless of what they're marked with
+/// because it makes the assumption that if it's a valid command class, and the
+/// method is marked with the command attribute, it's intended to be a slash-
+/// command. This is not the case for this extension, so it will only register
+/// commands that are explicitly marked with an command type attribute, and will
+/// NOT make an assumption of the type, as that can lead to ambiguity between
+/// whether a command is meant to be a slash or text command at a glance.
+/// </remarks>
+/// </summary>
+internal static class TreeExtensions
+{
+    // Taken directly from Remora because it was convinient to use.
+    // Don't care what you say, I'm still terrified of a DMCA, Jax.
+    
+    private const int MaxRootCommandsOrGroups     = 100;
+    private const int MaxGroupCommands            = 25;
+    private const int MaxChoiceValues             = 25;
+    private const int MaxCommandParameters        = 25;
+    private const int MaxCommandStringifiedLength = 4000;
+    private const int MaxChoiceNameLength         = 100;
+    private const int MaxChoiceValueLength        = 100;
+    private const int MaxCommandDescriptionLength = 100;
+    private const int MaxTreeDepth                = 3; // Top level is a depth of 1
+    private const int RootDepth                   = 1;
+    
+    private const string NameRegexPattern = "^[a-z0-9_-]{1,32}$";
+
+    private static readonly Regex SlashRegex = new(NameRegexPattern, RegexOptions.Compiled);
+
+    public static Dictionary<SlashCommandIdentifier, OneOf<CommandNode, Dictionary<string, CommandNode>>> 
+        MapApplicationCommands
+        (
+            this CommandTree                   commandTree,
+            IReadOnlyList<IApplicationCommand> commands
+        )
+    {
+        var mapping = new Dictionary<SlashCommandIdentifier, OneOf<CommandNode, Dictionary<string, CommandNode>>>();
+
+        foreach (var command in commands)
+        {
+            var isContextOrRootCommand = !command.Options.IsDefined(out var options) ||
+                                         options.All(o => o.Type is not (SubCommand or SubCommandGroup));
+
+            if (isContextOrRootCommand)
+            {
+                //Attempt to find the node in the tree.
+                var commandNode = commandTree.Root.Children.OfType<CommandNode>()
+                                             .FirstOrDefault(c =>
+                                              {
+                                                  if (!c.Key.Equals(command.Name, StringComparison.OrdinalIgnoreCase))
+                                                      return false;
+
+                                                  if (!command.Options.IsDefined(out var options))
+                                                      return true;
+
+                                                  // Please don't give two overloads the same named options :c
+                                                  // This also should fix an issue that could be caused by having
+                                                  // two overloads, one serving as a context menu command,
+                                                  // and the other a slash, but I have no idea how likely that situation is.
+                                                  return c.Shape.Parameters
+                                                          .Select(p => p.Parameter.Name)
+                                                          .SequenceEqual(options.Select(o => o.Name));
+                                              });
+
+                if (commandNode is null)
+                    throw new InvalidOperationException("A command was not present in the command tree, but was present in the commands list, and cannot be mapped.");
+                
+                mapping.Add(new(command.GuildID, command.ID), commandNode);
+                
+                continue;
+            }
+
+            if (!command.Options.IsDefined(out options))
+                throw new InvalidOperationException("A command was marked as a group, but did not contain any sub-commands.");
+
+            foreach (var option in options)
+            {
+                
+            }
+        }
+    }
+    
+
+    internal static IEnumerable<(List<string> Path, CommandNode Node)> MapOptions
+        (
+            IParentNode               parent,
+            List<string>              outerPath,
+            IApplicationCommandOption option
+        )
+    {
+        
+    }
+
+
+}

--- a/src/Silk/Commands/ConfigTestCommand.cs
+++ b/src/Silk/Commands/ConfigTestCommand.cs
@@ -6,6 +6,7 @@ using Remora.Commands.Attributes;
 using Remora.Commands.Groups;
 using Remora.Discord.API.Abstractions.Objects;
 using Remora.Discord.API.Abstractions.Rest;
+using Remora.Discord.Commands.Attributes;
 using Remora.Discord.Commands.Contexts;
 using Remora.Results;
 using Silk.Data.Entities;
@@ -27,6 +28,7 @@ public class A : CommandGroup
 [Group("config")]
 [Description("Configure various settings for your guild!")]
 //[RequireDiscordPermission(DiscordPermission.ManageGuild)]
+
 public class ConfigTestCommand : CommandGroup
 {
     [Group("edit")]
@@ -55,6 +57,7 @@ public class ConfigTestCommand : CommandGroup
         }
 
         [Command("logging")]
+        [CommandType(ApplicationCommandType.ChatInput)]
         [Description("Edit the logging settings for your guild!")]
         [SuppressMessage("ReSharper", "RedundantBlankLines", Justification = "Too many parameters")]
         public async Task<Result> EditLogging

--- a/src/Silk/Commands/General/ClearCommand.cs
+++ b/src/Silk/Commands/General/ClearCommand.cs
@@ -71,7 +71,7 @@ public class ClearCommand : CommandGroup
         if (message?.ID.Timestamp.AddDays(14) < DateTimeOffset.UtcNow)
             return await _channels.CreateMessageAsync(_context.ChannelID, "You can specify messages up to two weeks old.");
         
-        var messageResult = await GetMessagesAsync(_context.ChannelID, message?.ID ?? default(Remora.Rest.Core.Optional<Snowflake>), messageCount + (skip + 1 ?? 1)); 
+        var messageResult = await GetMessagesAsync(_context.ChannelID, message?.ID ?? default(Optional<Snowflake>), messageCount + (skip + 1 ?? 1)); 
             
         if (!messageResult.IsSuccess)
             return Result<IMessage>.FromError(messageResult.Error);
@@ -116,7 +116,7 @@ public class ClearCommand : CommandGroup
     /// <param name="around">The ID of the message to fetch messages around</param>
     /// <param name="limit">The limit of messages. If around is not specified, and this is greater than 100, the request will be paginated.</param>
     /// <returns></returns>
-    private async Task<Result<IReadOnlyList<IMessage>>> GetMessagesAsync(Snowflake channelID, Remora.Rest.Core.Optional<Snowflake> around, int limit)
+    private async Task<Result<IReadOnlyList<IMessage>>> GetMessagesAsync(Snowflake channelID, Optional<Snowflake> around, int limit)
     {
         if (limit <= 100 || around.HasValue)
             return await _channels.GetChannelMessagesAsync(channelID, around, limit: limit);
@@ -124,7 +124,7 @@ public class ClearCommand : CommandGroup
         var messages = new List<IMessage>();
         
         var remaining = limit;
-        var before    = default(Remora.Rest.Core.Optional<Snowflake>);
+        var before    = default(Optional<Snowflake>);
 
         while (remaining > 0)
         {

--- a/src/Silk/Silk.csproj
+++ b/src/Silk/Silk.csproj
@@ -96,6 +96,7 @@
         <ProjectReference Include="..\..\plugins\PluginLoader.Unity\PluginLoader.Unity.csproj" />
         <ProjectReference Include="..\Silk.Data\Silk.Data.csproj" />
         <ProjectReference Include="..\Silk.Extensions\Silk.Extensions.csproj" />
+        <ProjectReference Include="..\Silk.Remora.SlashCommands\Silk.Remora.SlashCommands.csproj" />
         <ProjectReference Include="..\Silk.Shared\Silk.Shared.csproj" />
     </ItemGroup>
 


### PR DESCRIPTION
I have just one issue in Remora, and one which is not likely to be fixed thanks to the strong stance Jax and others take in regards to it, backed by Discord's decisions.

I've since decided to morph [this class](https://github.com/Nihlus/Remora.Discord/blob/master/Remora.Discord.Commands/Extensions/CommandTreeExtensions.cs) into something more suitable for what I had in mind.

Remora's built-in extensions class attempts to register everything currently existent in the command tree as a slash command (or context menu) unless specifically excluded. 

I've since made some changes, while keeping most of the code the same (or even using reflection to invoke some of Remora's methods) to "fix" this behavior.